### PR TITLE
✨ feat: Add Email verification for sign up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
 DATABASE_URL=postgresql://admin:root@localhost:5432/fairhub_local?sslmode=disable
+
+MAIL_HOST=sandbox.smtp.mailtrap.io
+MAIL_PORT=587
+MAIL_USER=89bd4974195df1
+MAIL_PASS=2b77ac61b0b6e6
+MAIL_FROM="Your App <example@calmi2.org>"
+
+EMAIL_VERIFICATION_DOMAIN=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 DATABASE_URL=postgresql://admin:root@localhost:5432/fairhub_local?sslmode=disable
 
-MAIL_HOST=sandbox.smtp.mailtrap.io
-MAIL_PORT=587
-MAIL_USER=89bd4974195df1
-MAIL_PASS=2b77ac61b0b6e6
-MAIL_FROM="Eye ACT <auth@envisionportal.io>"
+MAIL_HOST=
+MAIL_PORT=
+MAIL_USER=
+MAIL_PASS=
+MAIL_FROM=
 
-EMAIL_VERIFICATION_DOMAIN=http://localhost:3000
+EMAIL_VERIFICATION_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ MAIL_HOST=sandbox.smtp.mailtrap.io
 MAIL_PORT=587
 MAIL_USER=89bd4974195df1
 MAIL_PASS=2b77ac61b0b6e6
-MAIL_FROM="Your App <example@calmi2.org>"
+MAIL_FROM="Eye ACT <auth@envisionportal.io>"
 
 EMAIL_VERIFICATION_DOMAIN=http://localhost:3000

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,4 +4,12 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
   devtools: { enabled: true },
   modules: ["@nuxt/ui", "nuxt-auth-utils", "dayjs-nuxt"],
+  runtimeConfig: {
+    emailVerificationDomain: process.env.EMAIL_VERIFICATION_DOMAIN, 
+    mailHost: process.env.MAIL_HOST,
+    mailPort: process.env.MAIL_PORT,
+    mailUser: process.env.MAIL_USER,
+    mailPass: process.env.MAIL_PASS,
+    mailFrom: process.env.MAIL_FROM,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "date-fns": "^4.1.0",
+    "nodemailer": "^6.10.0",
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7"
   },
@@ -35,6 +37,7 @@
     "@prisma/client": "^6.3.0",
     "@stylistic/eslint-plugin-js": "^2.13.0",
     "@types/bcrypt": "^5.0.2",
+    "@types/nodemailer": "^6.4.17",
     "@typescript-eslint/parser": "^8.21.0",
     "dayjs-nuxt": "2.1.11",
     "eslint": "8.57.0",

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -54,8 +54,9 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
     .then(async () => {
       toast.add({
         title: "Account created successfully",
-        description: "You can now login",
-        icon: "material-symbols:check-circle-outline",
+        description: "Please check your email to verify your account before logging in.",
+        icon: "material-symbols:mail-outline",
+        color: "info",
       });
     })
     .catch((error) => {

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -57,7 +57,6 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
         description: "You can now login",
         icon: "material-symbols:check-circle-outline",
       });
-      await navigateTo("/login");
     })
     .catch((error) => {
       console.error(error.data);

--- a/pages/verify-email.vue
+++ b/pages/verify-email.vue
@@ -1,0 +1,55 @@
+<template>
+  <div v-if="loading" class="loading-spinner">Loading...</div>
+  <div v-else>
+    <h1>Email Verification</h1>
+    <p v-if="message" :class="messageClass">{{ message }}</p>
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+const route = useRoute();
+const toast = useToast();
+const token = route.query.token as string;  // Get token from query params
+let loading = true;
+let message = "";
+let errorMessage = "";
+let messageClass = "success";
+
+// Handle token validation and verification
+onMounted(async () => {
+  if (!token) {
+    loading = false;
+    errorMessage = "No verification token found in the URL.";
+    return;
+  }
+
+  try {
+    const response = await $fetch("/api/auth/verify-email", {
+      method: "POST",
+      body: { token },
+    });
+
+    message = response.message;
+    loading = false;
+    toast.add({
+      title: "Email Verified",
+      description: response.message,
+      color: "success",
+      icon: "material-symbols:check-circle-outline",
+    });
+
+    // Redirect after verification
+    navigateTo("/login");
+  } catch (error) {
+    loading = false;
+    toast.add({
+      title: "Verification Failed",
+      description: "An error occurred. Please try again later",
+      color: "error",
+      icon: "material-symbols:error",
+    });
+  }
+});
+</script>

--- a/server/api/auth/login.ts
+++ b/server/api/auth/login.ts
@@ -30,6 +30,14 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  // Check if the user has verified their email
+  if (!user.emailVerified) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: "Email not verified. Please check your email for the verification link.",
+    });
+  } 
+
   // Check if the password matches
   if (!(await compare(body.data.password, user.password))) {
     throw createError({

--- a/server/api/auth/signup.ts
+++ b/server/api/auth/signup.ts
@@ -3,6 +3,9 @@ import { hash } from "bcrypt";
 import { nanoid } from "nanoid";
 import { sendEmail } from "../../utils/sendEmail";
 import { addMinutes } from "date-fns";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const signupSchema = z.object({
   emailAddress: z.string().email(),
@@ -61,11 +64,11 @@ export default defineEventHandler(async (event) => {
 
   // Send verification email
   // TODO: Update to real domain 
-  const verificationLink = `http://localhost:3000/verify-email?token=${verificationToken}`;
+  const verificationLink = `${process.env.EMAIL_VERIFICATION_DOMAIN}/verify-email?token=${verificationToken}`;
   await sendEmail(
     newUser.emailAddress,
     "Verify Your Email Address",
-    `Click the link to verify your email: ${verificationLink}`
+    verificationLink
   );
 
   return { message: "Verification email sent. Please check your inbox." };

--- a/server/api/auth/signup.ts
+++ b/server/api/auth/signup.ts
@@ -3,9 +3,6 @@ import { hash } from "bcrypt";
 import { nanoid } from "nanoid";
 import { sendEmail } from "../../utils/sendEmail";
 import dayjs from "dayjs";
-import dotenv from "dotenv";
-
-dotenv.config();
 
 const signupSchema = z.object({
   emailAddress: z.string().email(),
@@ -15,6 +12,7 @@ const signupSchema = z.object({
 });
 
 export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig();
   const body = await readValidatedBody(event, (b) => signupSchema.safeParse(b));
 
   if (!body.success) {
@@ -63,7 +61,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Send verification email
-  const verificationLink = `${process.env.EMAIL_VERIFICATION_DOMAIN}/verify-email?token=${verificationToken}`;
+  const verificationLink = `${config.emailVerificationDomain}/verify-email?token=${verificationToken}`;
   await sendEmail(
     newUser.emailAddress,
     "Verify Your Email Address",

--- a/server/api/auth/signup.ts
+++ b/server/api/auth/signup.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 import { hash } from "bcrypt";
+import { nanoid } from "nanoid";
+import { sendEmail } from "../../utils/sendEmail";
+import { addMinutes } from "date-fns";
 
 const signupSchema = z.object({
   emailAddress: z.string().email(),
@@ -14,7 +17,7 @@ export default defineEventHandler(async (event) => {
   if (!body.success) {
     throw createError({
       statusCode: 400,
-      statusMessage: "Missing login credentials",
+      statusMessage: "Missing or invalid signup details",
     });
   }
 
@@ -34,6 +37,8 @@ export default defineEventHandler(async (event) => {
 
   // Create a new user
   const hashedPassword = await hash(body.data.password, 10);
+  const verificationToken = nanoid();
+  const tokenExpiry = addMinutes(new Date(), 30);
 
   const newUser = await prisma.user.create({
     data: {
@@ -41,6 +46,9 @@ export default defineEventHandler(async (event) => {
       familyName: body.data.familyName,
       givenName: body.data.givenName,
       password: hashedPassword,
+      emailVerified: false,
+      emailVerificationToken: verificationToken,
+      emailVerificationTokenExpires: tokenExpiry,
     },
   });
 
@@ -51,5 +59,14 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  return sendRedirect(event, "/login");
+  // Send verification email
+  // TODO: Update to real domain 
+  const verificationLink = `http://localhost:3000/verify-email?token=${verificationToken}`;
+  await sendEmail(
+    newUser.emailAddress,
+    "Verify Your Email Address",
+    `Click the link to verify your email: ${verificationLink}`
+  );
+
+  return { message: "Verification email sent. Please check your inbox." };
 });

--- a/server/api/auth/signup.ts
+++ b/server/api/auth/signup.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { hash } from "bcrypt";
 import { nanoid } from "nanoid";
 import { sendEmail } from "../../utils/sendEmail";
-import { addMinutes } from "date-fns";
+import dayjs from "dayjs";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -41,7 +41,7 @@ export default defineEventHandler(async (event) => {
   // Create a new user
   const hashedPassword = await hash(body.data.password, 10);
   const verificationToken = nanoid();
-  const tokenExpiry = addMinutes(new Date(), 30);
+  const tokenExpiry = dayjs().add(30, "minute").toDate();
 
   const newUser = await prisma.user.create({
     data: {
@@ -63,7 +63,6 @@ export default defineEventHandler(async (event) => {
   }
 
   // Send verification email
-  // TODO: Update to real domain 
   const verificationLink = `${process.env.EMAIL_VERIFICATION_DOMAIN}/verify-email?token=${verificationToken}`;
   await sendEmail(
     newUser.emailAddress,

--- a/server/api/auth/verify-email.ts
+++ b/server/api/auth/verify-email.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+const verifySchema = z.object({
+  token: z.string(),
+});
+
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, (b) => verifySchema.safeParse(b));
+
+  if (!body.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid or missing verification token",
+    });
+  }
+
+  // Find the user by verification token
+  const user = await prisma.user.findUnique({
+    where: {
+      emailVerificationToken: body.data.token,
+    },
+  });
+
+  if (!user) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Invalid or expired verification token",
+    });
+  }
+
+  // Check if the token has expired
+  if (user.emailVerificationTokenExpires && user.emailVerificationTokenExpires < new Date()) {
+    throw createError({
+      statusCode: 410,
+      statusMessage: "Verification token has expired. Please request a new one.",
+    });
+  }
+
+  // Mark email as verified and clear the token
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      emailVerified: true,
+      emailVerifiedAt: new Date(),
+      emailVerificationToken: null,
+      emailVerificationTokenExpires: null,
+    },
+  });
+
+  return { message: "Email successfully verified! You can now log in." };
+});

--- a/server/utils/sendEmail.ts
+++ b/server/utils/sendEmail.ts
@@ -1,16 +1,14 @@
 import nodemailer from "nodemailer";
-import dotenv from "dotenv";
-
-// Load environment variables from .env file
-dotenv.config(); 
 
 export const sendEmail = async (to: string, subject: string, text: string) => {
+  const config = useRuntimeConfig();
+
   const transporter = nodemailer.createTransport({
-    host: process.env.MAIL_HOST,
-    port: Number(process.env.MAIL_PORT),
+    host: config.mailHost,
+    port: Number(config.mailPort),
     auth: {
-      user: process.env.MAIL_USER,
-      pass: process.env.MAIL_PASS,
+      user: config.mailUser,
+      pass: config.mailPass,
     },
   });
 
@@ -83,7 +81,7 @@ export const sendEmail = async (to: string, subject: string, text: string) => {
   `;
 
   await transporter.sendMail({
-    from: process.env.MAIL_FROM,
+    from: config.mailFrom,
     to: to,
     subject: subject,
     text: text,

--- a/server/utils/sendEmail.ts
+++ b/server/utils/sendEmail.ts
@@ -1,22 +1,92 @@
 import nodemailer from "nodemailer";
+import dotenv from "dotenv";
 
-// TODO: Update from mailtrap sandbox to live email sending service
+// Load environment variables from .env file
+dotenv.config(); 
+
 export const sendEmail = async (to: string, subject: string, text: string) => {
   const transporter = nodemailer.createTransport({
-    host: "sandbox.smtp.mailtrap.io",
-    port: 587,
+    host: process.env.MAIL_HOST,
+    port: Number(process.env.MAIL_PORT),
     auth: {
-      user: "89bd4974195df1",
-      pass: "2b77ac61b0b6e6",
+      user: process.env.MAIL_USER,
+      pass: process.env.MAIL_PASS,
     },
   });
-  
+
+  const htmlContent = `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+      <title>Email Confirmation</title>
+      <style>
+        body {
+          background-color: #e9ecef;
+          font-family: Arial, sans-serif;
+          margin: 0;
+          padding: 0;
+        }
+        table {
+          border-collapse: collapse;
+          width: 100%;
+          max-width: 600px;
+          margin: auto;
+          background: #ffffff;
+          border-top: 3px solid #d4dadf;
+        }
+        h2 {
+          font-size: 32px;
+          font-weight: 700;
+          text-align: center;
+          padding: 36px 24px 0;
+        }
+        p {
+          font-size: 16px;
+          line-height: 24px;
+          padding: 24px;
+          text-align: center;
+        }
+        .button-container {
+          text-align: center;
+          padding: 12px;
+        }
+        .button {
+          background-color: #1a82e2;
+          color: #ffffff;
+          padding: 16px 36px;
+          text-decoration: none;
+          display: inline-block;
+          border-radius: 6px;
+          font-size: 16px;
+        }
+      </style>
+    </head>
+    <body>
+      <table>
+        <tr>
+          <td>
+            <h2>Confirm Your Email Address</h2>
+            <p>Please verify your email address for Eye ACT by clicking the button below.</p>
+            <div class="button-container">
+              <a href="${text}" class="button" target="_blank">Verify My Email</a>
+            </div>
+            <p>If the button does not work, please use the following link to verify your email:</p>
+            <p><a href="${text}">${text}</a></p>
+            <p>If you did not request this, please ignore this email.</p>
+          </td>
+        </tr>
+      </table>
+    </body>
+  </html>
+  `;
+
   await transporter.sendMail({
-    from: `"Your App" <xdong@calmi2.org>`,
+    from: process.env.MAIL_FROM,
     to: to,
     subject: subject,
     text: text,
-    html: "<b>This is a test email for verification.</b>",
+    html: htmlContent,
   });
 };
- 

--- a/server/utils/sendEmail.ts
+++ b/server/utils/sendEmail.ts
@@ -1,0 +1,21 @@
+import nodemailer from "nodemailer";
+
+export const sendEmail = async (to: string, subject: string, text: string) => {
+  const transporter = nodemailer.createTransport({
+    host: "sandbox.smtp.mailtrap.io",
+    port: 587,
+    auth: {
+      user: "89bd4974195df1",
+      pass: "2b77ac61b0b6e6",
+    },
+  });
+  
+  await transporter.sendMail({
+    from: `"Your App" <xdong@calmi2.org>`,
+    to: to,
+    subject: subject,
+    text: text,
+    html: "<b>This is a test email for verification.</b>",
+  });
+};
+ 

--- a/server/utils/sendEmail.ts
+++ b/server/utils/sendEmail.ts
@@ -1,5 +1,6 @@
 import nodemailer from "nodemailer";
 
+// TODO: Update from mailtrap sandbox to live email sending service
 export const sendEmail = async (to: string, subject: string, text: string) => {
   const transporter = nodemailer.createTransport({
     host: "sandbox.smtp.mailtrap.io",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,13 @@
   dependencies:
     undici-types "~6.20.0"
 
+"@types/nodemailer@^6.4.17":
+  version "6.4.17"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.17.tgz#5c82a42aee16a3dd6ea31446a1bd6a447f1ac1a4"
+  integrity sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==
+  dependencies:
+    "@types/node" "*"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
@@ -3772,6 +3779,11 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 dayjs-nuxt@2.1.11:
   version "2.1.11"
@@ -7271,6 +7283,11 @@ node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
+
+nodemailer@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.10.0.tgz#1f24c9de94ad79c6206f66d132776b6503003912"
+  integrity sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
1. Create an Email Verification Page
Extract the token from the URL query.
Call the backend endpoint to verify the email.
Show a success or failure page and redirect to the login page after successful verification.
2. Modify Signup API to Send Verification Email 
Generate a verification token and set an expiration time in the database.
Send an email with a verification link (/verify?token=...).
3. Update the Signup Page
Modify the onSubmit function to notify users to check their email after signup.
Remove the immediate redirect to /login.
4. Add a verification email HTML email template 
![38703](https://github.com/user-attachments/assets/f8f62b05-346d-4adf-aec4-d516bd3d7ef8)
![60244](https://github.com/user-attachments/assets/f455cc6c-f650-4257-9af9-7a05a9a944f4)

